### PR TITLE
Adds PATCH endpoint for partial employee updates

### DIFF
--- a/src/main/java/com/dj/cruddemo/rest/EmployeeRestController.java
+++ b/src/main/java/com/dj/cruddemo/rest/EmployeeRestController.java
@@ -1,22 +1,28 @@
 package com.dj.cruddemo.rest;
 
 
-import com.dj.cruddemo.dao.EmployeeDAO;
+
 import com.dj.cruddemo.entity.Employee;
 import com.dj.cruddemo.service.EmployeeService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
+
 
 @RestController
 @RequestMapping("/api")
 public class EmployeeRestController {
 
     private EmployeeService employeeService;
+    private ObjectMapper objectMapper;
 
     // quick and dirty: inject employee DAO (use constructor injection)
-    public EmployeeRestController(EmployeeService theEmployeeService) {
+    public EmployeeRestController(EmployeeService theEmployeeService, ObjectMapper theObjectMapper) {
         employeeService = theEmployeeService;
+        objectMapper = theObjectMapper;
     }
 
     // expose "/employees" endpoint and return list of employees
@@ -60,6 +66,29 @@ public class EmployeeRestController {
         return dbEmployee;
     }
 
+    // add mapping for PATCH /employees/{employeeId} - update existing employee
+    @PatchMapping("/employees/{employeeId}")
+    public Employee patchEmployee(@PathVariable int employeeId, @RequestBody Map<String, Object> patchPayload) {
+
+        Employee tempEmployee = employeeService.findById(employeeId);
+
+        // throw exception if null
+        if (tempEmployee == null) {
+            throw new RuntimeException("Employee not found with id: " + employeeId);
+        }
+
+        // throw exception if request body updates contains id
+        if (patchPayload.containsKey("id")) {
+            throw new RuntimeException("Employee id not allowed in request body: " + employeeId);
+        }
+
+        Employee patchedEmployee = apply(patchPayload, tempEmployee);
+
+        Employee dbEmployee = employeeService.save(patchedEmployee);
+
+        return dbEmployee;
+    }
+
     // add mapping for DELETE /employees/{employeeId} - delete employee
 
     @DeleteMapping("/employees/{employeeId}")
@@ -69,6 +98,21 @@ public class EmployeeRestController {
             throw new RuntimeException("Employee not found with id: " + employeeId);
         }
         employeeService.deleteById(employeeId);
+    }
+
+    // apply patch to employee
+    private Employee apply(Map<String, Object> patchPayload, Employee tempEmployee) {
+
+        // Convert employee object to a JSON object node
+        ObjectNode employeeNode = objectMapper.convertValue(tempEmployee, ObjectNode.class);
+
+        // Convert the patchPayload map to a JSON object node
+        ObjectNode patchNode = objectMapper.convertValue(patchPayload, ObjectNode.class);
+
+        // Merge the patch updates into the employee node
+        employeeNode.setAll(patchNode);
+
+        return objectMapper.convertValue(employeeNode, Employee.class);
     }
 
 }


### PR DESCRIPTION
Introduces a new PATCH /employees/{employeeId} endpoint to allow partial updates to employee records. Implements logic to merge the provided fields into the existing employee object using ObjectMapper. Validates input to prevent updates to the employee ID field and handle missing records gracefully.

Includes helper method to apply patch updates and integrates ObjectMapper through constructor injection.