### PR TITLE
Renames variable for clarity in deleteEmployee method

### DIFF
--- a/src/main/java/com/dj/cruddemo/rest/EmployeeRestController.java
+++ b/src/main/java/com/dj/cruddemo/rest/EmployeeRestController.java
@@ -93,8 +93,8 @@ public class EmployeeRestController {
 
     @DeleteMapping("/employees/{employeeId}")
     public void deleteEmployee(@PathVariable int employeeId) {
-        Employee theEmployee = employeeService.findById(employeeId);
-        if (theEmployee == null) {
+        Employee tempEmployee = employeeService.findById(employeeId);
+        if (tempEmployee == null) {
             throw new RuntimeException("Employee not found with id: " + employeeId);
         }
         employeeService.deleteById(employeeId);


### PR DESCRIPTION
Updates the variable name from `theEmployee` to `tempEmployee` in the `deleteEmployee` method to improve clarity and align with naming conventions. No functional behavior is altered.